### PR TITLE
:space_invader: more facet a11y - fixes #132

### DIFF
--- a/docs/_sections/forms.html
+++ b/docs/_sections/forms.html
@@ -320,7 +320,7 @@ $("#checkbox-optin").change(function(e){
 
     <p>The general structure is:
       <ul>
-        <li>a <code>nypl-facet-toggle</code> toggle button that controls the open/closed state of the widget,</li>
+        <li>a <code>nypl-facet-toggle</code> toggle button that controls the open/closed state of the widget <strong>with the facet name wrapped in an <code>h3</code> tag</strong>,</li>
         <li>a div of class <code>nypl-collapsible</code> which contains:</li>
         <li>a <code>nypl-facet-search</code> that reflects the <a href="#textFields">general structure of a text field element</a> followed by</li>
         <li>a fieldset of class <code>nypl-facet-list</code> with</li>
@@ -345,6 +345,8 @@ $("#checkbox-optin").change(function(e){
 
     <p class="nypl-a11y-note"><strong>Accessibility note:</strong> Similar to <a href="#radioButtons">Radiobutton/Checkbox Groups</a>, for proper screen reader behavior, each radiobutton or checkbox must be <code>aria-labelledby</code> <strong>both</strong> the title group's <code>button</code> tag and its own corresponding <code>label</code> tag.</p>
 
+    <p class="nypl-a11y-note"><strong>Accessibility note:</strong> The toggle button must wrap the facet name with an <code>h3</code> tag.</p>
+
     <p>A “Show X more” <a href="buttons.html#linkButton">link button</a> at the end of the list allows for the user to display X more items to select from. <strong>Important:</strong> When the facet has very few items or when no “Show X more” button is displayed, the class <code>nosearch</code> has to be added to the field. This will hide the search box.</p>
 
     <p>Toggling between closed and open states along with the affected <code>aria-expanded</code> values of the widget will be controlled via JavaScript. A <code>collapsed</code> class must be added (or removed) to the <code>nypl-searchable-field</code> and <code>nypl-collapsible</code> elements. The example below uses jQuery.</p>
@@ -356,7 +358,7 @@ $("#checkbox-optin").change(function(e){
 <div class="nypl-searchable-field" aria-expanded="true">
   <button type="button" id="searchable1" class="nypl-facet-toggle"
     aria-controls="nypl-searchable-field_facet1" aria-expanded="true">
-    Subject
+    <h3>Subject</h3>
     <svg aria-hidden="true" class="nypl-icon" preserveAspectRatio="xMidYMid meet" viewBox="0 0 68 24">
       <title>wedge down icon</title>
       <polygon points="67.938 0 34 24 0 0 10 0 34.1 16.4 58.144 0 67.938 0" />
@@ -413,7 +415,7 @@ $("#checkbox-optin").change(function(e){
 &lt;div class=&quot;nypl-searchable-field&quot; aria-expanded=&quot;true&quot;&gt;
   &lt;button type=&quot;button&quot; id=&quot;searchable1&quot; class=&quot;nypl-facet-toggle&quot;
     aria-controls=&quot;nypl-searchable-field_facet1&quot; aria-expanded=&quot;true&quot;&gt;
-    Subject
+    &lt;h3&gt;Subject&lt;/h3&gt;
     &lt;svg aria-hidden=&quot;true&quot; class=&quot;nypl-icon&quot; preserveAspectRatio=&quot;xMidYMid meet&quot; viewBox=&quot;0 0 68 24&quot;&gt;
       &lt;title&gt;wedge down icon&lt;/title&gt;
       &lt;polygon points=&quot;67.938 0 34 24 0 0 10 0 34.1 16.4 58.144 0 67.938 0&quot; /&gt;

--- a/docs/css/example-search-styles.css
+++ b/docs/css/example-search-styles.css
@@ -2179,7 +2179,8 @@ button:focus {
     .nypl-searchable-field button.nypl-facet-toggle h3 {
       font-size: inherit;
       margin: 0;
-      padding: 0; }
+      padding: 0;
+      pointer-events: none; }
     .nypl-searchable-field button.nypl-facet-toggle .nypl-icon {
       background-color: #776e64;
       border-radius: 0;

--- a/docs/css/example-search-styles.css
+++ b/docs/css/example-search-styles.css
@@ -2176,6 +2176,10 @@ button:focus {
     padding-top: 0.25rem;
     text-align: left;
     width: 100%; }
+    .nypl-searchable-field button.nypl-facet-toggle h3 {
+      font-size: inherit;
+      margin: 0;
+      padding: 0; }
     .nypl-searchable-field button.nypl-facet-toggle .nypl-icon {
       background-color: #776e64;
       border-radius: 0;

--- a/docs/css/example-styles.css
+++ b/docs/css/example-styles.css
@@ -2179,7 +2179,8 @@ button:focus {
     .nypl-searchable-field button.nypl-facet-toggle h3 {
       font-size: inherit;
       margin: 0;
-      padding: 0; }
+      padding: 0;
+      pointer-events: none; }
     .nypl-searchable-field button.nypl-facet-toggle .nypl-icon {
       background-color: #776e64;
       border-radius: 0;

--- a/docs/css/example-styles.css
+++ b/docs/css/example-styles.css
@@ -2176,6 +2176,10 @@ button:focus {
     padding-top: 0.25rem;
     text-align: left;
     width: 100%; }
+    .nypl-searchable-field button.nypl-facet-toggle h3 {
+      font-size: inherit;
+      margin: 0;
+      padding: 0; }
     .nypl-searchable-field button.nypl-facet-toggle .nypl-icon {
       background-color: #776e64;
       border-radius: 0;

--- a/docs/discovery-search.html
+++ b/docs/discovery-search.html
@@ -267,7 +267,7 @@
         <form action="" class="nypl-search-form" id="filter-search">
 <div class="nypl-searchable-field" aria-expanded="true">
   <button type="button" class="nypl-facet-toggle" aria-controls="nypl-searchable-field_material" aria-expanded="true">
-    Material Type
+    <h3>Material Type</h3>
     <svg aria-hidden="true" class="nypl-icon" preserveAspectRatio="xMidYMid meet" viewBox="0 0 68 24">
       <title>wedge down icon</title>
       <polygon points="67.938 0 34 24 0 0 10 0 34.1 16.4 58.144 0 67.938 0" />
@@ -310,7 +310,7 @@
 
 <div class="nypl-searchable-field">
   <button type="button" class="nypl-facet-toggle" aria-controls="nypl-searchable-field_subject" aria-expanded="true">
-    Subject
+    <h3>Subject</h3>
     <svg aria-hidden="true" class="nypl-icon" preserveAspectRatio="xMidYMid meet" viewBox="0 0 68 24">
       <title>wedge down icon</title>
       <polygon points="67.938 0 34 24 0 0 10 0 34.1 16.4 58.144 0 67.938 0" />
@@ -373,7 +373,7 @@
 
 <div class="nypl-searchable-field nosearch collapsed">
   <button type="button" class="nypl-facet-toggle" aria-controls="nypl-searchable-field_material" aria-expanded="true">
-    Issuance
+    <h3>Issuance</h3>
     <svg aria-hidden="true" class="nypl-icon" preserveAspectRatio="xMidYMid meet" viewBox="0 0 68 24">
       <title>wedge down icon</title>
       <polygon points="67.938 0 34 24 0 0 10 0 34.1 16.4 58.144 0 67.938 0" />
@@ -406,7 +406,7 @@
 
 <div class="nypl-searchable-field">
   <button type="button" class="nypl-facet-toggle" aria-controls="nypl-searchable-field_material" aria-expanded="true">
-    Publisher
+    <h3>Publisher</h3>
     <svg aria-hidden="true" class="nypl-icon" preserveAspectRatio="xMidYMid meet" viewBox="0 0 68 24">
       <title>wedge down icon</title>
       <polygon points="67.938 0 34 24 0 0 10 0 34.1 16.4 58.144 0 67.938 0" />
@@ -450,7 +450,7 @@
 
 <div class="nypl-searchable-field nosearch collapsed">
   <button type="button" class="nypl-facet-toggle" aria-controls="nypl-searchable-field_material" aria-expanded="false">
-    Language
+    <h3>Language</h3>
     <svg aria-hidden="true" class="nypl-icon" preserveAspectRatio="xMidYMid meet" viewBox="0 0 68 24">
       <title>wedge down icon</title>
       <polygon points="67.938 0 34 24 0 0 10 0 34.1 16.4 58.144 0 67.938 0" />

--- a/sass/_forms.scss
+++ b/sass/_forms.scss
@@ -355,6 +355,12 @@ $form-padding: 0.5rem;
     text-align: left;
     width: 100%;
 
+    h3 {
+      font-size: inherit;
+      margin: 0;
+      padding: 0;
+    }
+
     .nypl-icon {
       @include nypl-icon($fill: $page-background-color, $background-color: $nypl-search-color-dark);
       @include transition(all, $hover-time, ease-in);

--- a/sass/_forms.scss
+++ b/sass/_forms.scss
@@ -359,6 +359,7 @@ $form-padding: 0.5rem;
       font-size: inherit;
       margin: 0;
       padding: 0;
+      pointer-events: none;
     }
 
     .nypl-icon {


### PR DESCRIPTION
more facet a11y... just wrap the facet name in an h3... inside the button:

````html
    <button type="button" id="searchable1" class="nypl-facet-toggle"
    aria-controls="nypl-searchable-field_facet1" aria-expanded="true">
    <h3>Subject</h3> <!-- ← THIS -->
    <svg aria-hidden="true" class="nypl-icon" preserveAspectRatio="xMidYMid meet" viewBox="0 0 68 24">
      <title>wedge down icon</title>
      <polygon points="67.938 0 34 24 0 0 10 0 34.1 16.4 58.144 0 67.938 0" />
    </svg>
  </button>
````