### PR TITLE
:space_invader: proposing a new collapsible field

### DIFF
--- a/docs/_sections/forms.html
+++ b/docs/_sections/forms.html
@@ -336,9 +336,96 @@ $("#checkbox-optin").change(function(e){
 &lt;/div&gt;
     </code></pre>
 
+    <h3 id="collapsibleFieldsets">Collapsible Fields</h3>
+
+    <p>Collapsible fields group multiple form fields into a collapsible box. This allows for better organization and display of multiple visually different form fields.</p>
+
+    <p>The general structure is:
+      <ul>
+        <li>a <code>nypl-facet-toggle</code> toggle button that controls the open/closed state of the widget <strong>with the facet name wrapped in an <code>h3</code> tag</strong>,</li>
+        <li>a div of class <code>nypl-collapsible</code> which contains the fields.</li>
+      </ul>
+    </p>
+
+    <p class="nypl-a11y-note"><strong>Accessibility note:</strong> The toggle button must wrap the facet name with an <code>h3</code> tag.</p>
+
+    <p>Toggling between closed and open states along with the affected <code>aria-expanded</code> values of the widget will be controlled via JavaScript. A <code>collapsed</code> class must be added (or removed) to the <code>nypl-collapsible-field</code> and <code>nypl-collapsible</code> elements. The example below uses jQuery.</p>
+
+    <p><strong>NOTE:</strong> The widget defaults to the <strong>open state</strong> but is <strong>closed via JavaScript on page load</strong>. This is to support situations where JavaScript may be disabled and allow users to see and interact with the facets.</p>
+
+    <div class="nypl-toolkit-example">
+      <span class="nypl-example-text">Example</span>
+<div class="nypl-collapsible-field" aria-expanded="true">
+  <button type="button" id="date" class="nypl-facet-toggle"
+    aria-controls="nypl-collapsible-field_date" aria-expanded="true">
+    <h3>Date</h3>
+    <svg aria-hidden="true" class="nypl-icon" preserveAspectRatio="xMidYMid meet" viewBox="0 0 68 24">
+      <title>wedge down icon</title>
+      <polygon points="67.938 0 34 24 0 0 10 0 34.1 16.4 58.144 0 67.938 0" />
+    </svg>
+  </button>
+  <div class="nypl-collapsible" id="nypl-collapsible-field_date" aria-expanded="true">
+    <div class="nypl-year-field">
+      <label for="date-from1">On or After Year</label>
+      <input id="date-from1" type="number" min="0" max="9999" step="1">
+    </div>
+    <div class="nypl-year-field">
+      <label for="date-to1">On or Before Year</label>
+      <input id="date-to1" type="number" min="0" max="9999" step="1">
+    </div>
+  </div>
+</div>
+    </div>
+
+    <pre><code class="scss">
+.nypl-collapsible-field
+.nypl-collapsible
+.collapsed
+    </code></pre>
+
+    <pre><code class="html">
+&lt;div class=&quot;nypl-collapsible-field&quot; aria-expanded=&quot;true&quot;&gt;
+  &lt;button type=&quot;button&quot; id=&quot;date&quot; class=&quot;nypl-facet-toggle&quot;
+    aria-controls=&quot;nypl-collapsible-field_date&quot; aria-expanded=&quot;true&quot;&gt;
+    &lt;h3&gt;Date&lt;/h3&gt;
+    &lt;svg aria-hidden=&quot;true&quot; class=&quot;nypl-icon&quot; preserveAspectRatio=&quot;xMidYMid meet&quot; viewBox=&quot;0 0 68 24&quot;&gt;
+      &lt;title&gt;wedge down icon&lt;/title&gt;
+      &lt;polygon points=&quot;67.938 0 34 24 0 0 10 0 34.1 16.4 58.144 0 67.938 0&quot; /&gt;
+    &lt;/svg&gt;
+  &lt;/button&gt;
+  &lt;div class=&quot;nypl-collapsible&quot; id=&quot;nypl-collapsible-field_date&quot; aria-expanded=&quot;true&quot;&gt;
+    &lt;div class=&quot;nypl-year-field&quot;&gt;
+      &lt;label for=&quot;date-from1&quot;&gt;On or After Year&lt;/label&gt;
+      &lt;input id=&quot;date-from1&quot; type=&quot;number&quot; min=&quot;0&quot; max=&quot;9999&quot; step=&quot;1&quot;&gt;
+    &lt;/div&gt;
+    &lt;div class=&quot;nypl-year-field&quot;&gt;
+      &lt;label for=&quot;date-to1&quot;&gt;On or Before Year&lt;/label&gt;
+      &lt;input id=&quot;date-to1&quot; type=&quot;number&quot; min=&quot;0&quot; max=&quot;9999&quot; step=&quot;1&quot;&gt;
+    &lt;/div&gt;
+  &lt;/div&gt;
+&lt;/div&gt;
+    </code></pre>
+    <pre><code class="js">
+// jQuery example
+$("button.nypl-facet-toggle").click(function (e) {
+  toggleFacet(e)
+})
+
+function toggleFacet(e) {
+  var button = $(e.target)
+  var facet = button.parent()
+  var collapsible = facet.find(".nypl-collapsible")
+  button.attr("aria-expanded", button.attr("aria-expanded") == "false" ? "true" : "false")
+  facet.attr("aria-expanded", facet.attr("aria-expanded") == "false" ? "true" : "false")
+  collapsible.attr("aria-expanded", collapsible.attr("aria-expanded") == "false" ? "true" : "false")
+  facet.toggleClass("collapsed")
+  collapsible.toggleClass("collapsed")
+}
+    </code></pre>
+
     <h3 id="searchableFieldsets">Searchable Fields</h3>
 
-    <p>Searchable fields allow the user to see many non-exclusive options at the same time while also searching within the option list. Use searchable facets when the list of potential selectable items is too large (i.e. more than a dozen or so). The text field should autocomplete (with result count) as the user types in it. By default, show the top 10 items sorted by the amount of results that will be returned.</p>
+    <p>Searchable are a version of the <a href="#collapsibleFieldsets">collapsible fieldsets</a> that allow the user to see many non-exclusive options at the same time while also searching within the option list. Use searchable facets when the list of potential selectable items is too large (i.e. more than a dozen or so). The text field should autocomplete (with result count) as the user types in it. By default, show the top 10 items sorted by the amount of results that will be returned.</p>
 
     <p>The general structure is:
       <ul>
@@ -374,6 +461,8 @@ $("#checkbox-optin").change(function(e){
     <p>Toggling between closed and open states along with the affected <code>aria-expanded</code> values of the widget will be controlled via JavaScript. A <code>collapsed</code> class must be added (or removed) to the <code>nypl-searchable-field</code> and <code>nypl-collapsible</code> elements. The example below uses jQuery.</p>
 
     <p><strong>NOTE:</strong> Place previously checked items <strong>first</strong> and without the number. The widget defaults to the <strong>open state</strong> but is <strong>closed via JavaScript on page load</strong>. This is to support situations where JavaScript may be disabled and allow users to see and interact with the facets.</p>
+
+    <p><strong>NOTE:</strong> As is the case of the <a href="#radioButtons">Radio Buttons</a> In this case the input tags are <strong>wrapped</strong> by the <code>label</code> tag.</p>
 
     <div class="nypl-toolkit-example">
       <span class="nypl-example-text">Example</span>
@@ -430,8 +519,6 @@ $("#checkbox-optin").change(function(e){
 .nypl-collapsible
 .collapsed
     </code></pre>
-
-    <p><strong>NOTE:</strong> As is the case of the <a href="#radioButtons">Radio Buttons</a> In this case the input tags are <strong>wrapped</strong> by the <code>label</code> tag.</p>
 
     <pre><code class="html">
 &lt;div class=&quot;nypl-searchable-field&quot; aria-expanded=&quot;true&quot;&gt;

--- a/docs/_sections/forms.html
+++ b/docs/_sections/forms.html
@@ -359,10 +359,7 @@ $("#checkbox-optin").change(function(e){
   <button type="button" id="date" class="nypl-facet-toggle"
     aria-controls="nypl-collapsible-field_date" aria-expanded="true">
     <h3>Date</h3>
-    <svg aria-hidden="true" class="nypl-icon" preserveAspectRatio="xMidYMid meet" viewBox="0 0 68 24">
-      <title>wedge down icon</title>
-      <polygon points="67.938 0 34 24 0 0 10 0 34.1 16.4 58.144 0 67.938 0" />
-    </svg>
+    <svg aria-hidden="true" class="nypl-icon" preserveAspectRatio="xMidYMid meet" viewBox="0 0 68 24"><title>wedge down icon</title><polygon points="67.938 0 34 24 0 0 10 0 34.1 16.4 58.144 0 67.938 0" /></svg>
   </button>
   <div class="nypl-collapsible" id="nypl-collapsible-field_date" aria-expanded="true">
     <div class="nypl-year-field">
@@ -388,10 +385,7 @@ $("#checkbox-optin").change(function(e){
   &lt;button type=&quot;button&quot; id=&quot;date&quot; class=&quot;nypl-facet-toggle&quot;
     aria-controls=&quot;nypl-collapsible-field_date&quot; aria-expanded=&quot;true&quot;&gt;
     &lt;h3&gt;Date&lt;/h3&gt;
-    &lt;svg aria-hidden=&quot;true&quot; class=&quot;nypl-icon&quot; preserveAspectRatio=&quot;xMidYMid meet&quot; viewBox=&quot;0 0 68 24&quot;&gt;
-      &lt;title&gt;wedge down icon&lt;/title&gt;
-      &lt;polygon points=&quot;67.938 0 34 24 0 0 10 0 34.1 16.4 58.144 0 67.938 0&quot; /&gt;
-    &lt;/svg&gt;
+    &lt;svg aria-hidden=&quot;true&quot; class=&quot;nypl-icon&quot; preserveAspectRatio=&quot;xMidYMid meet&quot; viewBox=&quot;0 0 68 24&quot;&gt;&lt;title&gt;wedge down icon&lt;/title&gt;&lt;polygon points=&quot;67.938 0 34 24 0 0 10 0 34.1 16.4 58.144 0 67.938 0&quot; /&gt;&lt;/svg&gt;
   &lt;/button&gt;
   &lt;div class=&quot;nypl-collapsible&quot; id=&quot;nypl-collapsible-field_date&quot; aria-expanded=&quot;true&quot;&gt;
     &lt;div class=&quot;nypl-year-field&quot;&gt;
@@ -470,10 +464,7 @@ function toggleFacet(e) {
   <button type="button" id="searchable1" class="nypl-facet-toggle"
     aria-controls="nypl-searchable-field_facet1" aria-expanded="true">
     <h3>Subject</h3>
-    <svg aria-hidden="true" class="nypl-icon" preserveAspectRatio="xMidYMid meet" viewBox="0 0 68 24">
-      <title>wedge down icon</title>
-      <polygon points="67.938 0 34 24 0 0 10 0 34.1 16.4 58.144 0 67.938 0" />
-    </svg>
+    <svg aria-hidden="true" class="nypl-icon" preserveAspectRatio="xMidYMid meet" viewBox="0 0 68 24"><title>wedge down icon</title><polygon points="67.938 0 34 24 0 0 10 0 34.1 16.4 58.144 0 67.938 0" /></svg>
   </button>
   <div class="nypl-collapsible" id="nypl-searchable-field_facet1" aria-expanded="true">
     <div class="nypl-facet-search">
@@ -525,10 +516,7 @@ function toggleFacet(e) {
   &lt;button type=&quot;button&quot; id=&quot;searchable1&quot; class=&quot;nypl-facet-toggle&quot;
     aria-controls=&quot;nypl-searchable-field_facet1&quot; aria-expanded=&quot;true&quot;&gt;
     &lt;h3&gt;Subject&lt;/h3&gt;
-    &lt;svg aria-hidden=&quot;true&quot; class=&quot;nypl-icon&quot; preserveAspectRatio=&quot;xMidYMid meet&quot; viewBox=&quot;0 0 68 24&quot;&gt;
-      &lt;title&gt;wedge down icon&lt;/title&gt;
-      &lt;polygon points=&quot;67.938 0 34 24 0 0 10 0 34.1 16.4 58.144 0 67.938 0&quot; /&gt;
-    &lt;/svg&gt;
+    &lt;svg aria-hidden=&quot;true&quot; class=&quot;nypl-icon&quot; preserveAspectRatio=&quot;xMidYMid meet&quot; viewBox=&quot;0 0 68 24&quot;&gt;&lt;title&gt;wedge down icon&lt;/title&gt;&lt;polygon points=&quot;67.938 0 34 24 0 0 10 0 34.1 16.4 58.144 0 67.938 0&quot; /&gt;&lt;/svg&gt;
   &lt;/button&gt;
   &lt;div class=&quot;nypl-collapsible&quot; id=&quot;nypl-searchable-field_facet1&quot; aria-expanded=&quot;true&quot;&gt;
     &lt;div class=&quot;nypl-facet-search&quot;&gt;

--- a/docs/css/example-search-styles.css
+++ b/docs/css/example-search-styles.css
@@ -2193,6 +2193,74 @@ button:focus {
       .nypl-mobile-refine.hidden {
         display: none; } }
 
+.nypl-facet-toggle {
+  background-color: #776e64;
+  border: 0;
+  border-radius: 0.2rem 0.2rem 0 0;
+  color: #fff;
+  cursor: pointer;
+  display: block;
+  font-weight: bold;
+  position: relative;
+  padding-bottom: 0.25rem;
+  padding-left: 0.5rem;
+  padding-right: 1.5rem;
+  padding-top: 0.25rem;
+  text-align: left;
+  width: 100%; }
+  .nypl-facet-toggle h3 {
+    font-size: inherit;
+    margin: 0;
+    padding: 0;
+    pointer-events: none; }
+  .nypl-facet-toggle .nypl-icon {
+    background-color: #776e64;
+    border-radius: 0;
+    display: inline-block;
+    fill: #fff;
+    height: 1em;
+    width: 1em;
+    speak: none;
+    -webkit-transition: all 0.1s ease-in 0s;
+    -moz-transition: all 0.1s ease-in 0s;
+    -o-transition: all 0.1s ease-in 0s;
+    transition: all 0.1s ease-in 0s;
+    position: absolute;
+    right: 0.5rem;
+    top: 0.65rem;
+    transform: rotate(180deg); }
+    .nypl-facet-toggle .nypl-icon.reversed {
+      background-color: inherit;
+      fill: #fff; }
+
+.nypl-collapsible-field {
+  background-color: #efedeb;
+  border: 0;
+  border-radius: 0.2rem;
+  box-shadow: none;
+  display: block;
+  margin: 1rem 0;
+  padding: 0;
+  position: relative;
+  padding-bottom: 0.5rem; }
+  .nypl-collapsible-field fieldset {
+    border: 0;
+    box-shadow: none;
+    margin: 0;
+    padding: 0; }
+  .nypl-collapsible-field label,
+  .nypl-collapsible-field legend {
+    color: #080807;
+    display: block;
+    font-weight: bold;
+    margin-left: 0.5rem; }
+  .nypl-collapsible-field .nypl-collapsible {
+    background-color: #c0bab4;
+    padding-left: 0.5rem;
+    padding-right: 0.5rem; }
+  .nypl-collapsible-field.collapsed .nypl-facet-toggle .nypl-icon {
+    transform: rotate(0deg); }
+
 .nypl-searchable-field {
   background-color: #efedeb;
   border: 0;
@@ -2202,8 +2270,8 @@ button:focus {
   margin: 1rem 0;
   padding: 0;
   position: relative;
-  border-radius: 0.2rem;
-  padding-bottom: 0.5rem; }
+  padding-bottom: 0.5rem;
+  border-radius: 0.2rem; }
   .nypl-searchable-field fieldset {
     border: 0;
     box-shadow: none;
@@ -2215,6 +2283,8 @@ button:focus {
     display: block;
     font-weight: bold;
     margin-left: 0.5rem; }
+  .nypl-searchable-field.collapsed .nypl-facet-toggle .nypl-icon {
+    transform: rotate(0deg); }
   .nypl-searchable-field span.nypl-label {
     color: #080807;
     display: block;
@@ -2229,45 +2299,6 @@ button:focus {
   .nypl-searchable-field input[type=checkbox] {
     height: initial;
     margin: 0 0.25rem 0 0; }
-  .nypl-searchable-field button.nypl-facet-toggle {
-    background-color: #776e64;
-    border: 0;
-    border-radius: 0.2rem 0.2rem 0 0;
-    color: #fff;
-    cursor: pointer;
-    display: block;
-    font-weight: bold;
-    position: relative;
-    padding-bottom: 0.25rem;
-    padding-left: 0.5rem;
-    padding-right: 1.5rem;
-    padding-top: 0.25rem;
-    text-align: left;
-    width: 100%; }
-    .nypl-searchable-field button.nypl-facet-toggle h3 {
-      font-size: inherit;
-      margin: 0;
-      padding: 0;
-      pointer-events: none; }
-    .nypl-searchable-field button.nypl-facet-toggle .nypl-icon {
-      background-color: #776e64;
-      border-radius: 0;
-      display: inline-block;
-      fill: #fff;
-      height: 1em;
-      width: 1em;
-      speak: none;
-      -webkit-transition: all 0.1s ease-in 0s;
-      -moz-transition: all 0.1s ease-in 0s;
-      -o-transition: all 0.1s ease-in 0s;
-      transition: all 0.1s ease-in 0s;
-      position: absolute;
-      right: 0.5rem;
-      top: 0.65rem;
-      transform: rotate(180deg); }
-      .nypl-searchable-field button.nypl-facet-toggle .nypl-icon.reversed {
-        background-color: inherit;
-        fill: #fff; }
   .nypl-searchable-field .nypl-facet-search {
     position: relative; }
     .nypl-searchable-field .nypl-facet-search label {
@@ -2341,8 +2372,6 @@ button:focus {
       text-align: right; }
   .nypl-searchable-field .nypl-link-button {
     margin: 0.5rem 0.5rem 0; }
-  .nypl-searchable-field.collapsed .nypl-facet-toggle .nypl-icon {
-    transform: rotate(0deg); }
   .nypl-searchable-field.nosearch .nypl-facet-search {
     display: none; }
 

--- a/docs/css/example-styles.css
+++ b/docs/css/example-styles.css
@@ -2193,6 +2193,74 @@ button:focus {
       .nypl-mobile-refine.hidden {
         display: none; } }
 
+.nypl-facet-toggle {
+  background-color: #776e64;
+  border: 0;
+  border-radius: 0.2rem 0.2rem 0 0;
+  color: #fff;
+  cursor: pointer;
+  display: block;
+  font-weight: bold;
+  position: relative;
+  padding-bottom: 0.25rem;
+  padding-left: 0.5rem;
+  padding-right: 1.5rem;
+  padding-top: 0.25rem;
+  text-align: left;
+  width: 100%; }
+  .nypl-facet-toggle h3 {
+    font-size: inherit;
+    margin: 0;
+    padding: 0;
+    pointer-events: none; }
+  .nypl-facet-toggle .nypl-icon {
+    background-color: #776e64;
+    border-radius: 0;
+    display: inline-block;
+    fill: #fff;
+    height: 1em;
+    width: 1em;
+    speak: none;
+    -webkit-transition: all 0.1s ease-in 0s;
+    -moz-transition: all 0.1s ease-in 0s;
+    -o-transition: all 0.1s ease-in 0s;
+    transition: all 0.1s ease-in 0s;
+    position: absolute;
+    right: 0.5rem;
+    top: 0.65rem;
+    transform: rotate(180deg); }
+    .nypl-facet-toggle .nypl-icon.reversed {
+      background-color: inherit;
+      fill: #fff; }
+
+.nypl-collapsible-field {
+  background-color: #efedeb;
+  border: 0;
+  border-radius: 0.2rem;
+  box-shadow: none;
+  display: block;
+  margin: 1rem 0;
+  padding: 0;
+  position: relative;
+  padding-bottom: 0.5rem; }
+  .nypl-collapsible-field fieldset {
+    border: 0;
+    box-shadow: none;
+    margin: 0;
+    padding: 0; }
+  .nypl-collapsible-field label,
+  .nypl-collapsible-field legend {
+    color: #080807;
+    display: block;
+    font-weight: bold;
+    margin-left: 0.5rem; }
+  .nypl-collapsible-field .nypl-collapsible {
+    background-color: #c0bab4;
+    padding-left: 0.5rem;
+    padding-right: 0.5rem; }
+  .nypl-collapsible-field.collapsed .nypl-facet-toggle .nypl-icon {
+    transform: rotate(0deg); }
+
 .nypl-searchable-field {
   background-color: #efedeb;
   border: 0;
@@ -2202,8 +2270,8 @@ button:focus {
   margin: 1rem 0;
   padding: 0;
   position: relative;
-  border-radius: 0.2rem;
-  padding-bottom: 0.5rem; }
+  padding-bottom: 0.5rem;
+  border-radius: 0.2rem; }
   .nypl-searchable-field fieldset {
     border: 0;
     box-shadow: none;
@@ -2215,6 +2283,8 @@ button:focus {
     display: block;
     font-weight: bold;
     margin-left: 0.5rem; }
+  .nypl-searchable-field.collapsed .nypl-facet-toggle .nypl-icon {
+    transform: rotate(0deg); }
   .nypl-searchable-field span.nypl-label {
     color: #080807;
     display: block;
@@ -2229,45 +2299,6 @@ button:focus {
   .nypl-searchable-field input[type=checkbox] {
     height: initial;
     margin: 0 0.25rem 0 0; }
-  .nypl-searchable-field button.nypl-facet-toggle {
-    background-color: #776e64;
-    border: 0;
-    border-radius: 0.2rem 0.2rem 0 0;
-    color: #fff;
-    cursor: pointer;
-    display: block;
-    font-weight: bold;
-    position: relative;
-    padding-bottom: 0.25rem;
-    padding-left: 0.5rem;
-    padding-right: 1.5rem;
-    padding-top: 0.25rem;
-    text-align: left;
-    width: 100%; }
-    .nypl-searchable-field button.nypl-facet-toggle h3 {
-      font-size: inherit;
-      margin: 0;
-      padding: 0;
-      pointer-events: none; }
-    .nypl-searchable-field button.nypl-facet-toggle .nypl-icon {
-      background-color: #776e64;
-      border-radius: 0;
-      display: inline-block;
-      fill: #fff;
-      height: 1em;
-      width: 1em;
-      speak: none;
-      -webkit-transition: all 0.1s ease-in 0s;
-      -moz-transition: all 0.1s ease-in 0s;
-      -o-transition: all 0.1s ease-in 0s;
-      transition: all 0.1s ease-in 0s;
-      position: absolute;
-      right: 0.5rem;
-      top: 0.65rem;
-      transform: rotate(180deg); }
-      .nypl-searchable-field button.nypl-facet-toggle .nypl-icon.reversed {
-        background-color: inherit;
-        fill: #fff; }
   .nypl-searchable-field .nypl-facet-search {
     position: relative; }
     .nypl-searchable-field .nypl-facet-search label {
@@ -2341,8 +2372,6 @@ button:focus {
       text-align: right; }
   .nypl-searchable-field .nypl-link-button {
     margin: 0.5rem 0.5rem 0; }
-  .nypl-searchable-field.collapsed .nypl-facet-toggle .nypl-icon {
-    transform: rotate(0deg); }
   .nypl-searchable-field.nosearch .nypl-facet-search {
     display: none; }
 

--- a/docs/discovery-search.html
+++ b/docs/discovery-search.html
@@ -352,14 +352,25 @@
   </div>
 </div>
 
-<div class="nypl-year-field">
-  <label for="date-from">On or After Year</label>
-  <input id="date-from" type="number" min="0" max="9999" step="1">
-</div>
-
-<div class="nypl-year-field">
-  <label for="date-to">On or Before Year</label>
-  <input id="date-to" type="number" min="0" max="9999" step="1">
+<div class="nypl-collapsible-field" aria-expanded="true">
+  <button type="button" id="date" class="nypl-facet-toggle"
+    aria-controls="nypl-collapsible-field_date" aria-expanded="true">
+    <h3>Date</h3>
+    <svg aria-hidden="true" class="nypl-icon" preserveAspectRatio="xMidYMid meet" viewBox="0 0 68 24">
+      <title>wedge down icon</title>
+      <polygon points="67.938 0 34 24 0 0 10 0 34.1 16.4 58.144 0 67.938 0" />
+    </svg>
+  </button>
+  <div class="nypl-collapsible" id="nypl-collapsible-field_date" aria-expanded="true">
+    <div class="nypl-year-field">
+      <label for="date-from1">On or After Year</label>
+      <input id="date-from1" type="number" min="0" max="9999" step="1">
+    </div>
+    <div class="nypl-year-field">
+      <label for="date-to1">On or Before Year</label>
+      <input id="date-to1" type="number" min="0" max="9999" step="1">
+    </div>
+  </div>
 </div>
 
 <div class="nypl-searchable-field nosearch collapsed">

--- a/sass/_forms.scss
+++ b/sass/_forms.scss
@@ -339,43 +339,61 @@ $form-padding: 0.5rem;
   }
 }
 
-@mixin searchable-field {
+@mixin facet-toggle {
+  background-color: $nypl-search-color-dark;
+  border: 0;
+  border-radius: $general-border-radius $general-border-radius 0 0;
+  color: $page-background-color;
+  cursor: pointer;
+  display: block;
+  font-weight: bold;
+  position: relative;
+  padding-bottom: 0.25rem;
+  padding-left: $form-padding;
+  padding-right: 1.5rem;
+  padding-top: 0.25rem;
+  text-align: left;
+  width: 100%;
+
+  h3 {
+    font-size: inherit;
+    margin: 0;
+    padding: 0;
+    pointer-events: none;
+  }
+
+  .nypl-icon {
+    @include nypl-icon($fill: $page-background-color, $background-color: $nypl-search-color-dark);
+    @include transition(all, $hover-time, ease-in);
+    position: absolute;
+    right: 0.5rem;
+    top: 0.65rem;
+    transform: rotate(180deg);
+  }
+}
+
+@mixin collapsible-field($is-searchable: false) {
   @include fieldset;
-  @include simple-radiobutton;
   padding-bottom: $form-padding;
 
-  button.nypl-facet-toggle {
-    background-color: $nypl-search-color-dark;
-    border: 0;
-    border-radius: $general-border-radius $general-border-radius 0 0;
-    color: $page-background-color;
-    cursor: pointer;
-    display: block;
-    font-weight: bold;
-    position: relative;
-    padding-bottom: 0.25rem;
-    padding-left: $form-padding;
-    padding-right: 1.5rem;
-    padding-top: 0.25rem;
-    text-align: left;
-    width: 100%;
-
-    h3 {
-      font-size: inherit;
-      margin: 0;
-      padding: 0;
-      pointer-events: none;
-    }
-
-    .nypl-icon {
-      @include nypl-icon($fill: $page-background-color, $background-color: $nypl-search-color-dark);
-      @include transition(all, $hover-time, ease-in);
-      position: absolute;
-      right: 0.5rem;
-      top: 0.65rem;
-      transform: rotate(180deg);
+  @if ($is-searchable == false) {
+    .nypl-collapsible {
+      background-color: darken($nypl-search-color, 10%);
+      padding-left: $form-padding;
+      padding-right: $form-padding;
     }
   }
+
+  &.collapsed {
+    .nypl-facet-toggle .nypl-icon {
+      transform: rotate(0deg);
+    }
+  }
+}
+
+@mixin searchable-field {
+  @include collapsible-field($is-searchable: true);
+  @include simple-radiobutton;
 
   .nypl-facet-search {
     @include text-field-with-label;
@@ -413,12 +431,6 @@ $form-padding: 0.5rem;
 
   .nypl-link-button {
     margin: $form-padding $form-padding 0;
-  }
-
-  &.collapsed {
-    .nypl-facet-toggle .nypl-icon {
-      transform: rotate(0deg);
-    }
   }
 
   &.nosearch {

--- a/sass/_toolkit.scss
+++ b/sass/_toolkit.scss
@@ -187,6 +187,14 @@
   @include mobile-refine;
 }
 
+.nypl-facet-toggle {
+  @include facet-toggle;
+}
+
+.nypl-collapsible-field {
+  @include collapsible-field;
+}
+
 .nypl-searchable-field {
   @include searchable-field;
 }


### PR DESCRIPTION
addresses and fixes #137 

it has bugged me that Before/After Year stand out from the rest of the facets and take up too much space when the user may or may not be interested in them. this also applies to any future widgets we may come up with that could be neatly “tucked in a drawer”.

basically the idea is to wrap the Before Year and After Year in a `nypl-collapsible-field` structure that ends up looking like this:

![image](https://cloud.githubusercontent.com/assets/133020/26412583/3c59a038-4077-11e7-8200-4d417e481bdb.png)

the gist of that structure is exactly the same as the other facets:

````html
<div class="nypl-collapsible-field" aria-expanded="true">
  <button type="button" id="date" class="nypl-facet-toggle"
    aria-controls="nypl-collapsible-field_date" aria-expanded="true">
    <h3>Date</h3>
    <svg aria-hidden="true" class="nypl-icon" preserveAspectRatio="xMidYMid meet" viewBox="0 0 68 24"><title>wedge down icon</title><polygon points="67.938 0 34 24 0 0 10 0 34.1 16.4 58.144 0 67.938 0" /></svg>
  </button>
  <div class="nypl-collapsible" id="nypl-collapsible-field_date" aria-expanded="true">
    <!-- ///////////////////// -->
    <!-- before and after here -->
    <!-- ///////////////////// -->
  </div>
</div>
````