### PR TITLE
:meat_on_bone: had to remove the dotted lines 

### DIFF
--- a/docs/css/example-search-styles.css
+++ b/docs/css/example-search-styles.css
@@ -710,8 +710,7 @@ legend {
   display: table; }
 
 a {
-  text-decoration: underline;
-  text-decoration-style: dotted; }
+  text-decoration: underline; }
   a:link {
     color: #1b7fa7; }
   a:visited {

--- a/docs/css/example-search-styles.v2.css
+++ b/docs/css/example-search-styles.v2.css
@@ -710,8 +710,7 @@ legend {
   display: table; }
 
 a {
-  text-decoration: underline;
-  text-decoration-style: dotted; }
+  text-decoration: underline; }
   a:link {
     color: #1b7fa7; }
   a:visited {

--- a/docs/css/example-styles.css
+++ b/docs/css/example-styles.css
@@ -710,8 +710,7 @@ legend {
   display: table; }
 
 a {
-  text-decoration: underline;
-  text-decoration-style: dotted; }
+  text-decoration: underline; }
   a:link {
     color: #1b7fa7; }
   a:visited {

--- a/sass/_nypl-normalize.scss
+++ b/sass/_nypl-normalize.scss
@@ -116,7 +116,6 @@ legend {
 
 a {
   text-decoration: underline;
-  text-decoration-style: dotted;
 
   &:link {
     color: $link-color;


### PR DESCRIPTION
Removed the dotted style from the underline links, due to inconsistent rendering across browsers. FF: looks good. Chrome: bad, Safari: doesnt obey dotted line, renders as regular underline. Opera: does weird stuff too...